### PR TITLE
build: fix and make next config generate a pre-rendered application (client side only)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,3 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: "export",
-};
-
-module.exports = nextConfig;
-
 const withPWA = require("next-pwa")({
   dest: "public",
   register: true,
@@ -12,36 +5,15 @@ const withPWA = require("next-pwa")({
   disable: process.env.NODE_ENV === "development",
 });
 
-module.exports = withPWA({
+/** @type {import('next').NextConfig} */
+const nextConfig = withPWA({
   basePath: "",
   reactStrictMode: true,
+  output: "export",
   images: {
     domains: ['bridge23.app', 'localhost'],
-  },
-  webpack(config, { dev, isServer }) {
-    if (!dev && !isServer) {
-      config.devtool = 'source-map';
-      config.optimization.minimize = false;
-    }
-    return config;
-  },
-  async headers() {
-    return [
-      {
-        source: "/.well-known/ii-alternative-origins",
-        headers: [
-          {
-            key: "Access-Control-Allow-Origin",
-            value: "*"
-          },
-          {
-            key: "Content-Type",
-            value: "application/json"
-          },
-        ],
-      },
-      // ... any other headers you need to set
-    ];
+    unoptimized: true,
   },
 });
 
+module.exports = nextConfig;


### PR DESCRIPTION
This PR addresses two things. Not sure those are exactly required but, that's the way I was able to produce a clean app locally.

1. There are two exports in the `next.config` which doesn't seem accurate

2. Your app using Internet Identity and NFID , you will have to make call from the client side anyways. Therefore this PR set your app to generate a pre-rendered / client side only app using the `output` export.